### PR TITLE
Stage-based AWS deploy defaults and decommission dev flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The app uses these AWS resources in production:
 4.  Amazon API Gateway HTTP API (public API entry point)
 5.  AWS Lambda (Spring backend runtime)
 6.  Amazon CloudWatch Logs (Lambda + API logs)
-7.  AWS Route 53 (DNS for `woodle.click` and `api.woodle.click`)
+7.  AWS Route 53 (DNS for `qs.woodle.click`/`api.qs.woodle.click` and `woodle.click`/`api.woodle.click`)
 8.  AWS Certificate Manager (TLS certificates for domains)
 9.  AWS Budgets + Cost Anomaly Detection (cost monitoring)
 
@@ -74,8 +74,8 @@ Rules:
 ## URL Patterns
 
 *   Create poll: `/poll/new`
-*   Participant link: absolute URL based on current origin, e.g. `https://woodle.click/poll/<UUID>` or `http://localhost:8088/poll/<UUID>`
-*   Admin link: absolute URL based on current origin, e.g. `https://woodle.click/poll/<UUID>-<admin-secret>` or `http://localhost:8088/poll/<UUID>-<admin-secret>`
+*   Participant link: absolute URL based on current origin, e.g. `https://qs.woodle.click/poll/<UUID>`, `https://woodle.click/poll/<UUID>`, or `http://localhost:8088/poll/<UUID>`
+*   Admin link: absolute URL based on current origin, e.g. `https://qs.woodle.click/poll/<UUID>-<admin-secret>`, `https://woodle.click/poll/<UUID>-<admin-secret>`, or `http://localhost:8088/poll/<UUID>-<admin-secret>`
 
 ## Persistence & Data Lifecycle
 
@@ -141,19 +141,25 @@ The AWS deployment script supports two runtime modes:
 JVM deployment example:
 
 ```bash
-AWS_REGION=eu-central-1 ENV_NAME=prod STACK_NAME=woodle-prod ./aws-deploy.sh
+./aws-deploy.sh
 ```
 
 Native deployment example:
 
 ```bash
-DEPLOY_RUNTIME=native AWS_REGION=eu-central-1 ENV_NAME=prod STACK_NAME=woodle-prod ./aws-deploy.sh
+DEPLOY_RUNTIME=native ./aws-deploy.sh
+```
+
+Production deployment example:
+
+```bash
+./aws-deploy.sh -prod
 ```
 
 Dry-run example (validate config/preflight only, no AWS or Docker changes):
 
 ```bash
-DRY_RUN=true DEPLOY_RUNTIME=native AWS_REGION=eu-central-1 ENV_NAME=prod STACK_NAME=woodle-prod ./aws-deploy.sh
+DRY_RUN=true DEPLOY_RUNTIME=native ./aws-deploy.sh
 ```
 
 ### Native AWS Guardrails (GraalVM)

--- a/infra/README.md
+++ b/infra/README.md
@@ -27,11 +27,11 @@ docker buildx build --platform linux/arm64 --provenance=false --sbom=false -f Do
 ```bash
 sam deploy \
   --template-file infra/template.yaml \
-  --stack-name woodle-dev \
+  --stack-name woodle-qs \
   --capabilities CAPABILITY_IAM \
   --region eu-central-1 \
   --parameter-overrides \
-    EnvironmentName=dev \
+    EnvironmentName=qs \
     LambdaImageUri=<account-id>.dkr.ecr.eu-central-1.amazonaws.com/woodle-lambda:latest
 ```
 
@@ -40,15 +40,16 @@ sam deploy \
 From repository root:
 
 ```bash
-./aws-deploy.sh
+./aws-deploy.sh        # default QS stage (qs.woodle.click)
+./aws-deploy.sh -prod  # production stage (woodle.click)
 ```
 
 Optional overrides:
 
 ```bash
-AWS_REGION=eu-central-1 ENV_NAME=dev STACK_NAME=woodle-dev ./aws-deploy.sh
-APP_DOMAIN_NAME=woodle.click ACM_CERTIFICATE_ARN=<acm-arn-in-us-east-1> ./aws-deploy.sh
-WOODLE_BACKEND_BASE_URL=https://api.woodle.click ./aws-deploy.sh
+AWS_REGION=eu-central-1 ENV_NAME=qs STACK_NAME=woodle-qs ./aws-deploy.sh
+APP_DOMAIN_NAME=qs.woodle.click ACM_CERTIFICATE_ARN=<acm-arn-in-us-east-1> ./aws-deploy.sh
+WOODLE_BACKEND_BASE_URL=https://api.qs.woodle.click ./aws-deploy.sh
 ```
 
 `WOODLE_BACKEND_BASE_URL` is optional. By default, deploy writes an empty backend base URL so frontend forms use


### PR DESCRIPTION
## Summary
- default deployment/wiring to QS stage domains (`qs.woodle.click`, `api.qs.woodle.click`) and add `-prod` switch for production
- harden deploy/wiring scripts with CloudFront alias preflight checks and ACM validation-record retry handling
- update AWS deployment docs/readme for per-stage stacks and commands
- decommission `woodle-dev` runtime path and validate `woodle-qs` + `woodle-prod` wiring flows

## Testing
- `./gradlew test --tests 'io.github.bodote.woodle.infra.NativeLambdaDeploymentModeTest'`
- smoke checks against both domains and APIs
