### PR TITLE
Tighten UI spacing and hide poll description heading

### DIFF
--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -48,6 +48,7 @@ header {
   position: relative;
   margin-bottom: 1.1rem;
   padding: 0.4rem 0.2rem;
+  text-align: center;
 }
 
 header::before {
@@ -82,7 +83,7 @@ h2 {
 }
 
 .step-indicator {
-  margin: 0.55rem 0 0;
+  margin: 0.55rem auto 0;
   width: fit-content;
   color: #0a4f95;
   background: color-mix(in srgb, var(--accent) 10%, #ffffff);
@@ -110,11 +111,11 @@ h2 {
 
 .wizard-card,
 .content-card {
-  padding: clamp(1.05rem, 0.65rem + 1.3vw, 1.8rem);
+  padding: clamp(0.9rem, 0.55rem + 1.1vw, 1.55rem);
 }
 
 .votes-panel {
-  padding: clamp(0.9rem, 0.55rem + 1vw, 1.4rem);
+  padding: clamp(0.8rem, 0.5rem + 0.9vw, 1.2rem);
 }
 
 .admin-layout {
@@ -136,7 +137,7 @@ h2 {
 
 .admin-panel,
 .info-card {
-  padding: 0.9rem;
+  padding: 0.78rem;
 }
 
 .admin-panel h2,
@@ -193,6 +194,11 @@ textarea::placeholder {
 textarea {
   resize: vertical;
   min-height: 7rem;
+}
+
+#poll-description {
+  min-height: 5.8rem;
+  padding: 0.5rem 0.62rem;
 }
 
 fieldset {
@@ -259,7 +265,7 @@ button {
   background: linear-gradient(135deg, var(--accent), #0f89de);
   font: inherit;
   font-size: 0.92rem;
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: 0.01em;
   cursor: pointer;
   box-shadow: var(--shadow-sm);
@@ -601,7 +607,7 @@ input[type="radio"] {
   background: linear-gradient(135deg, var(--accent), #0f89de);
   text-decoration: none;
   font-size: 0.92rem;
-  font-weight: 700;
+  font-weight: 600;
   box-shadow: var(--shadow-sm);
 }
 

--- a/src/main/resources/templates/poll/view.html
+++ b/src/main/resources/templates/poll/view.html
@@ -15,7 +15,6 @@
 
     <main class="panel-grid">
         <section class="content-card">
-            <h2>Beschreibung</h2>
             <p th:text="${poll.description}">Beschreibung</p>
         </section>
 


### PR DESCRIPTION
## Summary
- reduce button emphasis by lowering weight and size
- tighten padding across cards/panels and description textarea
- center main heading area and step indicator
- remove the "Beschreibung" heading on poll view while keeping description content

## Testing
- not run (visual/CSS-template-only changes)