### PR TITLE
Add schema version tracking and migration for polls

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Rules:
 *   No user accounts.
 *   Each poll has a UUID and a secret admin token.
 *   Polls are stored as a single JSON per UUID in S3.
+*   Poll JSON includes a top-level `schemaVersion` field. Default value is `"1"` (configurable via `woodle.poll.schema-version`).
+*   Rule for future schema changes: increment `schemaVersion` and add/maintain migration logic for older versions before rollout.
+*   Read-time migration: when a poll is loaded and `schemaVersion` is missing or lower than `woodle.poll.schema-version`, the app converts it to the current schema and immediately overwrites the S3 object before returning the poll to the UI.
 *   Polls are deleted after the expiry date.
 
 ## Product Spec (Date Poll)

--- a/src/main/java/io/github/bodote/woodle/adapter/out/persistence/PollDAO.java
+++ b/src/main/java/io/github/bodote/woodle/adapter/out/persistence/PollDAO.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 public record PollDAO(
         UUID pollId,
+        String schemaVersion,
         String type,
         String title,
         String descriptionHtml,

--- a/src/main/java/io/github/bodote/woodle/config/ApplicationConfig.java
+++ b/src/main/java/io/github/bodote/woodle/config/ApplicationConfig.java
@@ -35,6 +35,7 @@ public class ApplicationConfig {
     public PollRepository pollRepository(
             @Value("${woodle.s3.enabled:false}") boolean s3Enabled,
             @Value("${woodle.s3.bucket:woodle}") String bucketName,
+            @Value("${woodle.poll.schema-version:1}") String pollSchemaVersion,
             ObjectProvider<S3Client> s3ClientProvider,
             ObjectMapper objectMapper
     ) {
@@ -43,7 +44,7 @@ public class ApplicationConfig {
             if (s3Client == null) {
                 throw new IllegalStateException("S3 is enabled but no S3 client bean is available");
             }
-            return new S3PollRepository(s3Client, objectMapper, bucketName);
+            return new S3PollRepository(s3Client, objectMapper, bucketName, pollSchemaVersion);
         }
         return new InMemoryPollRepository();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,7 @@ woodle.s3.accessKey=${WOODLE_S3_ACCESS_KEY:dummy}
 woodle.s3.secretKey=${WOODLE_S3_SECRET_KEY:dummy}
 woodle.s3.pathStyle=${WOODLE_S3_PATH_STYLE:true}
 woodle.s3.bucket=${WOODLE_S3_BUCKET:woodle}
+woodle.poll.schema-version=${WOODLE_POLL_SCHEMA_VERSION:1}
 woodle.email.enabled=${WOODLE_EMAIL_ENABLED:false}
 woodle.email.from=${WOODLE_EMAIL_FROM:noreply@woodle.click}
 woodle.email.subject-prefix=${WOODLE_EMAIL_SUBJECT_PREFIX:}

--- a/src/test/java/io/github/bodote/woodle/adapter/in/web/PollErrorPageTest.java
+++ b/src/test/java/io/github/bodote/woodle/adapter/in/web/PollErrorPageTest.java
@@ -43,4 +43,15 @@ class PollErrorPageTest {
             org.junit.jupiter.api.Assertions.assertTrue(page.asNormalizedText().contains("Zeitpunkt"));
         }
     }
+
+    @Test
+    @DisplayName("returns bad request for invalid test-http-status parameter")
+    void returnsBadRequestForInvalidTestHttpStatusParameter() throws Exception {
+        try (WebClient webClient = MockMvcWebClientBuilder.mockMvcSetup(mockMvc).build()) {
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+            org.htmlunit.Page page = webClient.getPage("http://localhost/poll/error?test-http-status=999");
+
+            org.junit.jupiter.api.Assertions.assertEquals(400, page.getWebResponse().getStatusCode());
+        }
+    }
 }

--- a/woodle-spec.md
+++ b/woodle-spec.md
@@ -204,6 +204,9 @@ Die Benutzersicht zeigt eine tabellenbasierte Übersicht aller Teilnehmenden und
 - Unter dieser UUID werden Stammdaten der Umfrage sowie später die Auswahl/Antworten der Teilnehmenden gespeichert.
 - Jede Umfrage ist ausschließlich über einen Link erreichbar, der die UUID enthält.
 - Speicherung erfolgt in Amazon S3 (keine Datenbank).
+- Das gespeicherte Poll-JSON enthält ein Top-Level-Feld `schemaVersion` (Standard `"1"`, konfigurierbar über `woodle.poll.schema-version`).
+- Bei jeder Änderung des Poll-JSON-Schemas muss `schemaVersion` erhöht werden, damit ältere Polls erkannt und migriert/konvertiert werden können.
+- Beim Lesen einer Umfrage gilt: fehlt `schemaVersion` oder ist sie kleiner als `woodle.poll.schema-version`, wird die Umfrage auf das aktuelle Schema migriert und sofort in S3 überschrieben, bevor die Antwort an die UI zurückgeht.
 - Umfragen werden nach Ablauf des Verfallsdatums vollständig gelöscht (inklusive aller Antworten).
 
 # Flow (Event-Typ und Zeitlogik)


### PR DESCRIPTION
Summary
- document the new poll schema version field in the README/spec and add runtime property configuration
- persist schemaVersion in PollDAO, validate configuration early, and ensure migrations happen when loading older data while logging the activity
- extend S3PollRepository and related tests to cover schema enforcement, legacy migrations, and new failure cases

Testing
- Not run (not requested)