### PR TITLE
Add architectural guardrails and fix WizardState package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'software.amazon.awssdk:sesv2:2.25.67'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
     testImplementation 'org.htmlunit:htmlunit:3.11.0'
     testImplementation 'org.testcontainers:junit-jupiter:1.20.4'
     testImplementation 'org.testcontainers:localstack:1.20.4'

--- a/src/main/java/io/github/bodote/woodle/adapter/in/web/PollNewPageController.java
+++ b/src/main/java/io/github/bodote/woodle/adapter/in/web/PollNewPageController.java
@@ -1,5 +1,6 @@
 package io.github.bodote.woodle.adapter.in.web;
 
+import io.github.bodote.woodle.application.model.WizardState;
 import io.github.bodote.woodle.application.port.out.WizardStateRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/io/github/bodote/woodle/adapter/in/web/PollSubmitController.java
+++ b/src/main/java/io/github/bodote/woodle/adapter/in/web/PollSubmitController.java
@@ -1,5 +1,6 @@
 package io.github.bodote.woodle.adapter.in.web;
 
+import io.github.bodote.woodle.application.model.WizardState;
 import io.github.bodote.woodle.application.port.in.CreatePollResult;
 import io.github.bodote.woodle.application.port.in.CreatePollUseCase;
 import io.github.bodote.woodle.application.port.in.command.CreatePollCommand;

--- a/src/main/java/io/github/bodote/woodle/adapter/out/persistence/InMemoryWizardStateRepository.java
+++ b/src/main/java/io/github/bodote/woodle/adapter/out/persistence/InMemoryWizardStateRepository.java
@@ -1,6 +1,6 @@
 package io.github.bodote.woodle.adapter.out.persistence;
 
-import io.github.bodote.woodle.adapter.in.web.WizardState;
+import io.github.bodote.woodle.application.model.WizardState;
 import io.github.bodote.woodle.application.port.out.WizardStateRepository;
 
 import java.util.Optional;

--- a/src/main/java/io/github/bodote/woodle/adapter/out/persistence/S3WizardStateRepository.java
+++ b/src/main/java/io/github/bodote/woodle/adapter/out/persistence/S3WizardStateRepository.java
@@ -2,7 +2,7 @@ package io.github.bodote.woodle.adapter.out.persistence;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.bodote.woodle.adapter.in.web.WizardState;
+import io.github.bodote.woodle.application.model.WizardState;
 import io.github.bodote.woodle.application.port.out.WizardStateRepository;
 import io.github.bodote.woodle.domain.model.EventType;
 import software.amazon.awssdk.core.ResponseInputStream;

--- a/src/main/java/io/github/bodote/woodle/application/model/WizardState.java
+++ b/src/main/java/io/github/bodote/woodle/application/model/WizardState.java
@@ -1,4 +1,4 @@
-package io.github.bodote.woodle.adapter.in.web;
+package io.github.bodote.woodle.application.model;
 
 import io.github.bodote.woodle.domain.model.EventType;
 

--- a/src/main/java/io/github/bodote/woodle/application/port/out/WizardStateRepository.java
+++ b/src/main/java/io/github/bodote/woodle/application/port/out/WizardStateRepository.java
@@ -1,6 +1,6 @@
 package io.github.bodote.woodle.application.port.out;
 
-import io.github.bodote.woodle.adapter.in.web.WizardState;
+import io.github.bodote.woodle.application.model.WizardState;
 
 import java.util.Optional;
 import java.util.UUID;

--- a/src/test/java/io/github/bodote/woodle/adapter/in/web/PollStep3PageTest.java
+++ b/src/test/java/io/github/bodote/woodle/adapter/in/web/PollStep3PageTest.java
@@ -2,7 +2,7 @@ package io.github.bodote.woodle.adapter.in.web;
 
 import io.github.bodote.woodle.testfixtures.TestFixtures;
 
-import io.github.bodote.woodle.adapter.in.web.WizardState;
+import io.github.bodote.woodle.application.model.WizardState;
 import io.github.bodote.woodle.domain.model.EventType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/github/bodote/woodle/adapter/in/web/PollSubmitControllerTest.java
+++ b/src/test/java/io/github/bodote/woodle/adapter/in/web/PollSubmitControllerTest.java
@@ -7,7 +7,7 @@ import io.github.bodote.woodle.application.port.in.CreatePollUseCase;
 import io.github.bodote.woodle.application.port.in.CreatePollResult;
 import io.github.bodote.woodle.application.port.in.command.CreatePollCommand;
 import io.github.bodote.woodle.application.port.out.WizardStateRepository;
-import io.github.bodote.woodle.adapter.in.web.WizardState;
+import io.github.bodote.woodle.application.model.WizardState;
 import io.github.bodote.woodle.domain.model.EventType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/github/bodote/woodle/adapter/in/web/PollWizardFlowTest.java
+++ b/src/test/java/io/github/bodote/woodle/adapter/in/web/PollWizardFlowTest.java
@@ -2,7 +2,7 @@ package io.github.bodote.woodle.adapter.in.web;
 
 import io.github.bodote.woodle.testfixtures.TestFixtures;
 
-import io.github.bodote.woodle.adapter.in.web.WizardState;
+import io.github.bodote.woodle.application.model.WizardState;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;

--- a/src/test/java/io/github/bodote/woodle/adapter/in/web/WizardStateTest.java
+++ b/src/test/java/io/github/bodote/woodle/adapter/in/web/WizardStateTest.java
@@ -1,5 +1,6 @@
 package io.github.bodote.woodle.adapter.in.web;
 
+import io.github.bodote.woodle.application.model.WizardState;
 import io.github.bodote.woodle.domain.model.EventType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,7 +54,7 @@ class WizardStateTest {
         WizardState state = new WizardState();
         state.setEventType(EventType.INTRADAY);
 
-        Class<?> dayOptionClass = Class.forName("io.github.bodote.woodle.adapter.in.web.WizardState$DayOption");
+        Class<?> dayOptionClass = Class.forName("io.github.bodote.woodle.application.model.WizardState$DayOption");
         Object firstDay = dayOptionClass
                 .getDeclaredConstructor(LocalDate.class, List.class)
                 .newInstance(LocalDate.of(2026, 2, 1), List.of(LocalTime.of(10, 50), LocalTime.of(13, 50)));

--- a/src/test/java/io/github/bodote/woodle/adapter/out/persistence/InMemoryWizardStateRepositoryTest.java
+++ b/src/test/java/io/github/bodote/woodle/adapter/out/persistence/InMemoryWizardStateRepositoryTest.java
@@ -1,6 +1,6 @@
 package io.github.bodote.woodle.adapter.out.persistence;
 
-import io.github.bodote.woodle.adapter.in.web.WizardState;
+import io.github.bodote.woodle.application.model.WizardState;
 import io.github.bodote.woodle.domain.model.EventType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/github/bodote/woodle/adapter/out/persistence/S3WizardStateRepositoryTest.java
+++ b/src/test/java/io/github/bodote/woodle/adapter/out/persistence/S3WizardStateRepositoryTest.java
@@ -3,7 +3,7 @@ package io.github.bodote.woodle.adapter.out.persistence;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.github.bodote.woodle.adapter.in.web.WizardState;
+import io.github.bodote.woodle.application.model.WizardState;
 import io.github.bodote.woodle.domain.model.EventType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/io/github/bodote/woodle/architecture/ArchitectureRulesTest.java
+++ b/src/test/java/io/github/bodote/woodle/architecture/ArchitectureRulesTest.java
@@ -1,0 +1,56 @@
+package io.github.bodote.woodle.architecture;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@AnalyzeClasses(
+        packages = "io.github.bodote.woodle",
+        importOptions = ImportOption.DoNotIncludeTests.class
+)
+class ArchitectureRulesTest {
+
+    @ArchTest
+    static final ArchRule domain_does_not_depend_on_application_adapter_or_config =
+            noClasses()
+                    .that().resideInAPackage("..domain..")
+                    .should().dependOnClassesThat()
+                    .resideInAnyPackage("..application..", "..adapter..", "..config..");
+
+    @ArchTest
+    static final ArchRule domain_does_not_depend_on_spring_or_jakarta =
+            noClasses()
+                    .that().resideInAPackage("..domain..")
+                    .should().dependOnClassesThat()
+                    .resideInAnyPackage("org.springframework..", "jakarta..");
+
+    @ArchTest
+    static final ArchRule application_does_not_depend_on_adapter_or_config =
+            noClasses()
+                    .that().resideInAPackage("..application..")
+                    .should().dependOnClassesThat()
+                    .resideInAnyPackage("..adapter..", "..config..");
+
+    @ArchTest
+    static final ArchRule application_and_domain_do_not_depend_on_web_adapter_types =
+            noClasses()
+                    .that().resideInAnyPackage("..application..", "..domain..")
+                    .should().dependOnClassesThat()
+                    .resideInAnyPackage("..adapter.in.web..");
+
+    @ArchTest
+    static final ArchRule dto_suffix_is_reserved_for_web_adapter_transfer_types =
+            classes()
+                    .that().haveSimpleNameEndingWith("DTO")
+                    .should().resideInAPackage("..adapter.in.web..");
+
+    @ArchTest
+    static final ArchRule dao_suffix_is_reserved_for_persistence_adapter_types =
+            classes()
+                    .that().haveSimpleNameEndingWith("DAO")
+                    .should().resideInAPackage("..adapter.out.persistence..");
+}

--- a/src/test/java/io/github/bodote/woodle/testfixtures/TestFixtures.java
+++ b/src/test/java/io/github/bodote/woodle/testfixtures/TestFixtures.java
@@ -1,6 +1,6 @@
 package io.github.bodote.woodle.testfixtures;
 
-import io.github.bodote.woodle.adapter.in.web.WizardState;
+import io.github.bodote.woodle.application.model.WizardState;
 import io.github.bodote.woodle.domain.model.EventType;
 import io.github.bodote.woodle.domain.model.Poll;
 import io.github.bodote.woodle.domain.model.PollOption;


### PR DESCRIPTION
Summary
- add ArchUnit dependency and a focused architecture test to enforce domain/application/adapter layers and DTO/DAO naming
- relocate `WizardState` into the application model package so adapters/ports consistently reference the shared definition
- update all imports and references to align with the new package

Testing
- Not run (not requested)